### PR TITLE
fix: the maximum call stack size error occurs when a non entity value is exported

### DIFF
--- a/src/util/DirectoryExportedClassesLoader.ts
+++ b/src/util/DirectoryExportedClassesLoader.ts
@@ -16,7 +16,7 @@ export async function importClassesFromDirectories(logger: Logger, directories: 
         } else if (Array.isArray(mod)) {
             mod.forEach((i: any) => loadFileClasses(i, allLoaded));
 
-        } else {
+        } else if (typeof mod === "object" && mod !== null) {
             Object.keys(mod).forEach(key => loadFileClasses(mod[key], allLoaded));
 
         }


### PR DESCRIPTION
Related to: #8