### PR TITLE
update: bump deno to v0.36.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     - uses: actions/checkout@master
     - uses: denolib/setup-deno@master
       with:
-        deno-version: 0.33.0
+        deno-version: 0.36.0
     - name: Run tests
       run: |
         cp ./ormconfig.gh-actions.json ./ormconfig.json

--- a/dem.json
+++ b/dem.json
@@ -3,11 +3,10 @@
     {
       "protocol": "https",
       "path": "deno.land/std",
-      "version": "v0.33.0",
+      "version": "v0.36.0",
       "files": [
         "/fmt/colors.ts",
         "/fs/mod.ts",
-        "/node/module.ts",
         "/path/mod.ts",
         "/util/async.ts"
       ]

--- a/dem.json
+++ b/dem.json
@@ -30,7 +30,7 @@
     {
       "protocol": "https",
       "path": "deno.land/x/sqlite",
-      "version": "d451a28e55180730a296a9383cd5dd26155a2c11",
+      "version": "73935087a1ebe9108d784503bc5474662ba54b73",
       "files": [
         "/mod.ts"
       ]

--- a/src/decorator/columns/Column.ts
+++ b/src/decorator/columns/Column.ts
@@ -90,7 +90,7 @@ export function Column(type: (type?: any) => Function, options?: ColumnEmbeddedO
  * Column decorator is used to mark a specific class property as a table column.
  * Only properties decorated with this decorator will be persisted to the database when entity be saved.
  */
-export function Column(typeOrOptions: ((type?: any) => Function)|ColumnType|(ColumnOptions&ColumnEmbeddedOptions), options?: (ColumnOptions&ColumnEmbeddedOptions)): Function {
+export function Column(typeOrOptions: ((type?: any) => Function)|ColumnType|(ColumnOptions&ColumnEmbeddedOptions), options?: (ColumnOptions&ColumnEmbeddedOptions) | (ColumnCommonOptions&ColumnHstoreOptions)): Function {
     return function (object: Object, propertyName: string) {
 
         // normalize parameters
@@ -105,26 +105,26 @@ export function Column(typeOrOptions: ((type?: any) => Function)|ColumnType|(Col
         if (!options) options = {} as ColumnOptions;
 
         // check if there is no type in column options then set type from first function argument, or guessed one
-        if (!options.type && type)
-            options.type = type;
+        if (!(options as ColumnOptions).type && type)
+            (options as ColumnOptions).type = type;
 
         // specify HSTORE type if column is HSTORE
-        if (options.type === "hstore" && !options.hstoreType)
-            options.hstoreType = "string";
+        if ((options as ColumnOptions).type === "hstore" && !(options as ColumnOptions).hstoreType)
+            (options as ColumnOptions).hstoreType = "string";
 
         if (typeOrOptions instanceof Function) { // register an embedded
             getMetadataArgsStorage().embeddeds.push({
                 target: object.constructor,
                 propertyName: propertyName,
                 isArray: options.array === true,
-                prefix: options.prefix !== undefined ? options.prefix : undefined,
+                prefix: (options as ColumnEmbeddedOptions).prefix !== undefined ? (options as ColumnEmbeddedOptions).prefix : undefined,
                 type: typeOrOptions as (type?: any) => Function
             } as EmbeddedMetadataArgs);
 
         } else { // register a regular column
 
             // if we still don't have a type then we need to give error to user that type is required
-            if (!options.type)
+            if (!(options as ColumnOptions).type)
                 throw new ColumnTypeUndefinedError(object, propertyName);
 
             // create unique

--- a/src/decorator/transaction/Transaction.ts
+++ b/src/decorator/transaction/Transaction.ts
@@ -18,7 +18,7 @@ import {IsolationLevel} from "../../driver/types/IsolationLevel.ts";
 export function Transaction(connectionName?: string): MethodDecorator;
 export function Transaction(options?: TransactionOptions): MethodDecorator;
 export function Transaction(connectionOrOptions?: string | TransactionOptions): MethodDecorator {
-    return function (target: Object, methodName: string, descriptor: PropertyDescriptor) {
+    return function (target: Object, methodName: string | symbol, descriptor: PropertyDescriptor) {
 
         // save original method - we gonna need it
         const originalMethod = descriptor.value;
@@ -45,10 +45,10 @@ export function Transaction(connectionOrOptions?: string | TransactionOptions): 
 
                 // filter all @TransactionEntityManager() and @TransactionRepository() decorator usages for this method
                 const transactionEntityManagerMetadatas = getMetadataArgsStorage()
-                    .filterTransactionEntityManagers(target.constructor, methodName)
+                    .filterTransactionEntityManagers(target.constructor, methodName as string)
                     .reverse();
                 const transactionRepositoryMetadatas = getMetadataArgsStorage()
-                    .filterTransactionRepository(target.constructor, methodName)
+                    .filterTransactionRepository(target.constructor, methodName as string)
                     .reverse();
 
                 // if there are @TransactionEntityManager() decorator usages the inject them

--- a/src/decorator/transaction/TransactionRepository.ts
+++ b/src/decorator/transaction/TransactionRepository.ts
@@ -6,8 +6,8 @@ import {CannotReflectMethodParameterTypeError} from "../../error/CannotReflectMe
  * Injects transaction's repository into the method wrapped with @Transaction decorator.
  */
 export function TransactionRepository(entityType?: Function): ParameterDecorator {
-    return (object: Object, methodName: string, index: number) => {
+    return (object: Object, methodName: string | symbol, index: number) => {
 
-         throw new CannotReflectMethodParameterTypeError(object.constructor, methodName);
+         throw new CannotReflectMethodParameterTypeError(object.constructor, methodName as string);
     };
 }

--- a/src/driver/sqlite/SqliteDriver.ts
+++ b/src/driver/sqlite/SqliteDriver.ts
@@ -50,7 +50,18 @@ export class SqliteDriver extends AbstractSqliteDriver {
      */
     async disconnect(): Promise<void> {
         this.queryRunner = undefined;
-        this.databaseConnection.close();
+        try {
+            this.databaseConnection.close();
+        } catch (error) {
+            if (error.code === 5) { // SqliteBusy
+                // FIXME
+                // This problem occurs since deno-sqlite@73935087a1ebe9108d784503bc5474662ba54b73.
+                // We need more research...
+                console.warn(error); // this.connection.logger.log("warn", error.message);
+            } else {
+                throw error;
+            }
+        }
     }
 
     /**

--- a/src/driver/sqlite/SqliteQueryRunner.ts
+++ b/src/driver/sqlite/SqliteQueryRunner.ts
@@ -38,7 +38,7 @@ export class SqliteQueryRunner extends AbstractSqliteQueryRunner {
             throw new QueryRunnerAlreadyReleasedError();
 
         const connection = this.driver.connection;
-        const reportSlowQuery = function (): void {
+        const reportSlowQuery = (): void => {
 
             // log slow queries if maxQueryExecution time is set
             const maxQueryExecutionTime = connection.options.maxQueryExecutionTime;

--- a/src/entity-manager/EntityManager.ts
+++ b/src/entity-manager/EntityManager.ts
@@ -950,7 +950,7 @@ export class EntityManager {
         // convert possible embeded path "social.likes" into object { social: { like: () => value } }
         const values: QueryDeepPartialEntity<Entity> = propertyPath
             .split(".")
-            .reduceRight(
+            .reduceRight<any>(
                 (value, key) => ({ [key]: value }) as any,
                 () => this.connection.driver.escape(column.databaseName) + " + " + value
             );
@@ -982,7 +982,7 @@ export class EntityManager {
         // convert possible embeded path "social.likes" into object { social: { like: () => value } }
         const values: QueryDeepPartialEntity<Entity> = propertyPath
             .split(".")
-            .reduceRight(
+            .reduceRight<any>(
                 (value, key) => ({ [key]: value }) as any,
                 () => this.connection.driver.escape(column.databaseName) + " - " + value
             );

--- a/src/util/DepGraph.ts
+++ b/src/util/DepGraph.ts
@@ -75,7 +75,7 @@ export class DepGraph {
                     if (idx >= 0) {
                         edgeList[key].splice(idx, 1);
                     }
-                }, this);
+                }/*, this*/);
             });
         }
     }

--- a/test/functional/repository/basic-methods/model-schema/QuestionSchema.ts
+++ b/test/functional/repository/basic-methods/model-schema/QuestionSchema.ts
@@ -1,3 +1,5 @@
+import type {Question} from "../model/Question.ts";
+
 export default {
     name: "Question",
     table: {
@@ -14,7 +16,7 @@ export default {
             nullable: false
         }
     },
-    target: function Question() {
+    target: function Question(this: Question) {
         this.type = "question";
     }
 };

--- a/test/functional/transaction/transaction-decorator/controller/PostController.ts
+++ b/test/functional/transaction/transaction-decorator/controller/PostController.ts
@@ -11,9 +11,9 @@ import {CategoryRepository} from "../repository/CategoryRepository.ts";
 export class PostController {
 
     @Transaction("mysql") // "mysql" is a connection name. you can not pass it if you are using default connection.
-    async save(post: Post, category: Category, @TransactionManager() entityManager: EntityManager) {
-        await entityManager.save(post);
-        await entityManager.save(category);
+    async save(post: Post, category: Category, @TransactionManager() entityManager?: EntityManager) {
+        await entityManager!.save(post);
+        await entityManager!.save(category);
     }
 
     // this save is not wrapped into the transaction
@@ -27,19 +27,19 @@ export class PostController {
     async saveWithRepository(
         post: Post,
         category: Category,
-        /*@TransactionRepository(Post)*/postRepository: Repository<Post>,
-        /*@TransactionRepository()*/categoryRepository: CategoryRepository,
+        /*@TransactionRepository(Post)*/postRepository?: Repository<Post>,
+        /*@TransactionRepository()*/categoryRepository?: CategoryRepository,
     ) {
-        await postRepository.save(post);
-        await categoryRepository.save(category);
+        await postRepository!.save(post);
+        await categoryRepository!.save(category);
 
-        return categoryRepository.findByName(category.name);
+        return categoryRepository!.findByName(category.name);
     }
 
     @Transaction({ connectionName: "mysql", isolation: "SERIALIZABLE" }) // "mysql" is a connection name. you can not pass it if you are using default connection.
-    async saveWithNonDefaultIsolation(post: Post, category: Category, @TransactionManager() entityManager: EntityManager) {
-        await entityManager.save(post);
-        await entityManager.save(category);
+    async saveWithNonDefaultIsolation(post: Post, category: Category, @TransactionManager() entityManager?: EntityManager) {
+        await entityManager!.save(post);
+        await entityManager!.save(category);
     }
 
 }

--- a/test/utils/test-utils.ts
+++ b/test/utils/test-utils.ts
@@ -7,10 +7,8 @@ import {EntitySchema} from "../../src/entity-schema/EntitySchema.ts";
 import {createConnections} from "../../src/index.ts";
 import {NamingStrategyInterface} from "../../src/naming-strategy/NamingStrategyInterface.ts";
 import {PromiseUtils} from "../../src/util/PromiseUtils.ts";
-import {createRequire} from "../../vendor/https/deno.land/std/node/module.ts";
 import {join} from "../../vendor/https/deno.land/std/path/mod.ts";
 
-const require = createRequire(import.meta.url);
 const __dirname = getDirnameOfCurrentModule(import.meta);
 
 export function getDirnameOfCurrentModule(meta: ImportMeta): string {
@@ -169,10 +167,10 @@ export function getTypeOrmConfig(): TestingConnectionOptions[] {
     try {
 
         try {
-            return require(__dirname + "/../../../../ormconfig.json");
+            return readJSONFile(__dirname + "/../../../../ormconfig.json");
 
         } catch (err) {
-            return require(join(__dirname + "../../ormconfig.json"));
+            return readJSONFile(join(__dirname + "../../ormconfig.json"));
         }
 
     } catch (err) {
@@ -302,10 +300,20 @@ export function generateRandomText(length: number): string {
 
 export function sleep(ms: number): Promise<void> {
     return new Promise<void>(ok => {
-        setTimeout(ok, ms);
+        setTimeout(() => ok(), ms);
     });
 }
 
 export function allSettled(values: any[]): Promise<Array<{ status: 'fulfilled' | 'rejected', value?: any, reason?: any }>> {
     return (Promise as any).allSettled(values);
+}
+
+let jsonFileCache = {} as { [path: string]: any };
+function readJSONFile(path: string): any {
+    if (jsonFileCache[path]) {
+        return jsonFileCache[path];
+    }
+    const decoder = new TextDecoder();
+    jsonFileCache[path] = JSON.parse(decoder.decode(Deno.readFileSync(path)));
+    return jsonFileCache[path];
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,7 @@
 {
     "version": "2.1.1",
     "compilerOptions": {
+        "strict": true,
         "target": "esnext",
         "experimentalDecorators": true,
         "sourceMap": true,

--- a/vendor/https/deno.land/std/fmt/colors.ts
+++ b/vendor/https/deno.land/std/fmt/colors.ts
@@ -1,1 +1,1 @@
-export * from 'https://deno.land/std@v0.33.0/fmt/colors.ts';
+export * from 'https://deno.land/std@v0.36.0/fmt/colors.ts';

--- a/vendor/https/deno.land/std/fs/mod.ts
+++ b/vendor/https/deno.land/std/fs/mod.ts
@@ -1,1 +1,1 @@
-export * from 'https://deno.land/std@v0.33.0/fs/mod.ts';
+export * from 'https://deno.land/std@v0.36.0/fs/mod.ts';

--- a/vendor/https/deno.land/std/node/module.ts
+++ b/vendor/https/deno.land/std/node/module.ts
@@ -1,1 +1,0 @@
-export * from 'https://deno.land/std@v0.33.0/node/module.ts';

--- a/vendor/https/deno.land/std/path/mod.ts
+++ b/vendor/https/deno.land/std/path/mod.ts
@@ -1,1 +1,1 @@
-export * from 'https://deno.land/std@v0.33.0/path/mod.ts';
+export * from 'https://deno.land/std@v0.36.0/path/mod.ts';

--- a/vendor/https/deno.land/std/util/async.ts
+++ b/vendor/https/deno.land/std/util/async.ts
@@ -1,1 +1,1 @@
-export * from 'https://deno.land/std@v0.33.0/util/async.ts';
+export * from 'https://deno.land/std@v0.36.0/util/async.ts';

--- a/vendor/https/deno.land/x/sqlite/mod.ts
+++ b/vendor/https/deno.land/x/sqlite/mod.ts
@@ -1,1 +1,1 @@
-export * from 'https://deno.land/x/sqlite@d451a28e55180730a296a9383cd5dd26155a2c11/mod.ts';
+export * from 'https://deno.land/x/sqlite@73935087a1ebe9108d784503bc5474662ba54b73/mod.ts';


### PR DESCRIPTION
- Closes #21.
- Bump deno-sqlite to 73935087a1ebe9108d784503bc5474662ba54b73.
  - This update introduces the following error:

```
  1) query builder > sub-query
       "after all" hook for "should execute sub query in joins as string (as selection)":
     SqliteError: unable to close due to unfinalized statements or unfinished backups
      at DB._error (https://deno.land/x/sqlite@73935087a1ebe9108d784503bc5474662ba54b73/src/db.js:265:16)
      at DB.close (https://deno.land/x/sqlite@73935087a1ebe9108d784503bc5474662ba54b73/src/db.js:242:18)
      at SqliteDriver.disconnect (SqliteDriver.ts:53:33)
      at Connection.close (Connection.ts:223:27)
      at test-utils.ts:278:104
      at Array.map (<anonymous>)
      at closeTestingConnections (test-utils.ts:278:36)
      at Context.<anonymous> (query-builder-subquery.ts:24:17)
      at callFn (https://unpkg.com/mocha@7.0.0/mocha.js:5420:21)
      at Hook.Runnable.run (https://unpkg.com/mocha@7.0.0/mocha.js:5407:7)
```