### PR TITLE
release: v0.2.23-rc2

### DIFF
--- a/src/version.ts
+++ b/src/version.ts
@@ -1,3 +1,3 @@
-export const VERSION = "v0.2.23-rc1";
+export const VERSION = "v0.2.23-rc2";
 export const MOD_URL = `https://denolib.com/denolib/typeorm@${VERSION}/mod.ts`;
 export const CLI_URL = `https://denolib.com/denolib/typeorm@${VERSION}/cli.ts`;


### PR DESCRIPTION
- update: bump Deno to v0.39.0 (#43)
- update: bump deno-postgres to v0.3.9 (#43)
- fix: modify the SqliteDriver's API to behave more like the original TypeORM's SqljsDriver (to support the browser in the future) (#41)
- fix: restrict dynamic imports to the local file system (#36)