### PR TITLE
update: bump Deno to v0.42.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     - uses: actions/checkout@master
     - uses: denolib/setup-deno@master
       with:
-        deno-version: 0.39.0
+        deno-version: 0.42.0
     - name: Run tests
       run: |
         cp ./ormconfig.gh-actions.json ./ormconfig.json

--- a/dem.json
+++ b/dem.json
@@ -15,7 +15,7 @@
     {
       "protocol": "https",
       "path": "deno.land/x/postgres",
-      "version": "v0.3.9",
+      "version": "v0.3.11",
       "files": [
         "/mod.ts"
       ]

--- a/dem.json
+++ b/dem.json
@@ -3,7 +3,7 @@
     {
       "protocol": "https",
       "path": "deno.land/std",
-      "version": "v0.39.0",
+      "version": "v0.42.0",
       "files": [
         "/fmt/colors.ts",
         "/fs/mod.ts",

--- a/src/driver/postgres/PostgresConnectionCredentialsOptions.ts
+++ b/src/driver/postgres/PostgresConnectionCredentialsOptions.ts
@@ -38,6 +38,6 @@ export interface PostgresConnectionCredentialsOptions {
     /**
      * Object with ssl parameters
      */
-    readonly ssl?: boolean | Deno.ListenTLSOptions;
+    readonly ssl?: boolean | Deno.ListenTlsOptions;
 
 }

--- a/src/platform/PlatformTools.ts
+++ b/src/platform/PlatformTools.ts
@@ -76,7 +76,7 @@ export class PlatformTools {
         return path.resolve(pathStr);
     }
 
-    static expandGlob(pattern: string): AsyncIterableIterator<{filename: string}> {
+    static expandGlob(pattern: string): AsyncIterableIterator<{path: string}> {
         return fs.expandGlob(pattern, { includeDirs: false });
     }
 
@@ -107,7 +107,7 @@ export class PlatformTools {
      * Gets environment variable.
      */
     static getEnvVariable(name: string): any {
-        return Deno.env()[name];
+        return Deno.env.get(name);
     }
 
     static encodeToBase64(string: string): string {

--- a/src/util/DirectoryExportedClassesLoader.ts
+++ b/src/util/DirectoryExportedClassesLoader.ts
@@ -25,8 +25,8 @@ export async function importClassesFromDirectories(logger: Logger, directories: 
 
     const allFiles = [] as string[];
     for (const dir of directories) {
-        for await (const {filename} of PlatformTools.expandGlob(dir)) {
-            allFiles.push(filename);
+        for await (const {path} of PlatformTools.expandGlob(dir)) {
+            allFiles.push(path);
         }
     }
 

--- a/test/functional/connection-options-reader/connection-options-reader.ts
+++ b/test/functional/connection-options-reader/connection-options-reader.ts
@@ -7,8 +7,8 @@ import {ConnectionOptionsReader} from "../../../src/connection/ConnectionOptions
 describe("ConnectionOptionsReader", () => {
   const __dirname = getDirnameOfCurrentModule(import.meta);
   after(() => {
-    delete Deno.env().TYPEORM_CONNECTION;
-    delete Deno.env().TYPEORM_DATABASE;
+    delete Deno.env.toObject().TYPEORM_CONNECTION;
+    delete Deno.env.toObject().TYPEORM_DATABASE;
   });
 
   it("properly loads config with entities specified", async function() {
@@ -45,7 +45,7 @@ describe("ConnectionOptionsReader", () => {
     const connectionOptionsReader = new ConnectionOptionsReader({ root: __dirname, configName: "configs/.env" });
     const [ fileOptions ]: ConnectionOptions[] = await connectionOptionsReader.all();
     expect(fileOptions.database).to.have.string("test-js");
-    expect(Deno.env().TYPEORM_DATABASE).to.equal("test-js");
+    expect(Deno.env.toObject().TYPEORM_DATABASE).to.equal("test-js");
   });
 });
 

--- a/vendor/https/deno.land/std/fmt/colors.ts
+++ b/vendor/https/deno.land/std/fmt/colors.ts
@@ -1,1 +1,1 @@
-export * from 'https://deno.land/std@v0.39.0/fmt/colors.ts';
+export * from 'https://deno.land/std@v0.42.0/fmt/colors.ts';

--- a/vendor/https/deno.land/std/fs/mod.ts
+++ b/vendor/https/deno.land/std/fs/mod.ts
@@ -1,1 +1,1 @@
-export * from 'https://deno.land/std@v0.39.0/fs/mod.ts';
+export * from 'https://deno.land/std@v0.42.0/fs/mod.ts';

--- a/vendor/https/deno.land/std/node/process.ts
+++ b/vendor/https/deno.land/std/node/process.ts
@@ -1,1 +1,1 @@
-export * from 'https://deno.land/std@v0.39.0/node/process.ts';
+export * from 'https://deno.land/std@v0.42.0/node/process.ts';

--- a/vendor/https/deno.land/std/path/mod.ts
+++ b/vendor/https/deno.land/std/path/mod.ts
@@ -1,1 +1,1 @@
-export * from 'https://deno.land/std@v0.39.0/path/mod.ts';
+export * from 'https://deno.land/std@v0.42.0/path/mod.ts';

--- a/vendor/https/deno.land/std/util/async.ts
+++ b/vendor/https/deno.land/std/util/async.ts
@@ -1,1 +1,1 @@
-export * from 'https://deno.land/std@v0.39.0/util/async.ts';
+export * from 'https://deno.land/std@v0.42.0/util/async.ts';

--- a/vendor/https/deno.land/x/postgres/mod.ts
+++ b/vendor/https/deno.land/x/postgres/mod.ts
@@ -1,1 +1,1 @@
-export * from 'https://deno.land/x/postgres@v0.3.9/mod.ts';
+export * from 'https://deno.land/x/postgres@v0.3.11/mod.ts';


### PR DESCRIPTION
- This PR closes #46.
- Bumped Deno to v0.42.0 in CI
- Bumped std to v0.42.0
- Bumped deno-postgres to v0.3.11