### PR TITLE
update: Bump Deno to v1.0.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,4 +29,4 @@ jobs:
     - name: Run tests
       run: |
         cp ./ormconfig.gh-actions.json ./ormconfig.json
-        deno run --allow-read --allow-write --allow-env --allow-net --config ./tsconfig.json -r ./test.ts
+        deno run --allow-read --allow-write --allow-env --allow-net --unstable --config ./tsconfig.json -r ./test.ts

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
     - uses: actions/checkout@master
     - uses: denolib/setup-deno@master
       with:
-        deno-version: 0.42.0
+        deno-version: 1.0.0
     - name: Run tests
       run: |
         cp ./ormconfig.gh-actions.json ./ormconfig.json

--- a/dem.json
+++ b/dem.json
@@ -39,7 +39,7 @@
     {
       "protocol": "https",
       "path": "deno.land/x/sqlite",
-      "version": "73935087a1ebe9108d784503bc5474662ba54b73",
+      "version": "v1.0.0",
       "files": [
         "/mod.ts"
       ]

--- a/dem.json
+++ b/dem.json
@@ -47,7 +47,7 @@
     {
       "protocol": "https",
       "path": "unpkg.com/cac",
-      "version": "v6.5.8",
+      "version": "v6.5.9",
       "files": [
         "/mod.js"
       ]

--- a/dem.json
+++ b/dem.json
@@ -3,13 +3,13 @@
     {
       "protocol": "https",
       "path": "deno.land/std",
-      "version": "v0.42.0",
+      "version": "v0.51.0",
       "files": [
+        "/async/deferred.ts",
         "/fmt/colors.ts",
         "/fs/mod.ts",
         "/node/process.ts",
-        "/path/mod.ts",
-        "/util/async.ts"
+        "/path/mod.ts"
       ]
     },
     {

--- a/dem.json
+++ b/dem.json
@@ -15,7 +15,7 @@
     {
       "protocol": "https",
       "path": "deno.land/x/mysql",
-      "version": "1.9.1",
+      "version": "2.1.0",
       "files": [
         "/mod.ts"
       ]

--- a/dem.json
+++ b/dem.json
@@ -23,7 +23,7 @@
     {
       "protocol": "https",
       "path": "deno.land/x/postgres",
-      "version": "v0.3.11",
+      "version": "v0.4.0",
       "files": [
         "/mod.ts"
       ]

--- a/ormconfig.gh-actions.json
+++ b/ormconfig.gh-actions.json
@@ -1,13 +1,13 @@
 [
   {
-    "skip": false,
+    "skip": true,
     "name": "sqlite",
     "type": "sqlite",
     "database": ":memory:",
     "logging": false
   },
   {
-    "skip": true,
+    "skip": false,
     "name": "postgres",
     "type": "postgres",
     "host": "localhost",

--- a/ormconfig.gh-actions.json
+++ b/ormconfig.gh-actions.json
@@ -1,13 +1,13 @@
 [
   {
-    "skip": true,
+    "skip": false,
     "name": "sqlite",
     "type": "sqlite",
     "database": ":memory:",
     "logging": false
   },
   {
-    "skip": false,
+    "skip": true,
     "name": "postgres",
     "type": "postgres",
     "host": "localhost",

--- a/src/connection/ConnectionOptionsReader.ts
+++ b/src/connection/ConnectionOptionsReader.ts
@@ -116,7 +116,7 @@ export class ConnectionOptionsReader {
             connectionOptions = await mod.default;
 
         } else if (foundFileFormat === "json") {
-            connectionOptions = await import(configFile);
+            connectionOptions = await this.loadJson(configFile);
 
         } else if (foundFileFormat === "yml") {
             connectionOptions = new ConnectionOptionsYmlReader().read(configFile);
@@ -134,6 +134,12 @@ export class ConnectionOptionsReader {
         }
 
         return undefined;
+    }
+
+    protected async loadJson(path: string): Promise<ConnectionOptions> {
+        const content = await PlatformTools.readFile(path);
+        const decoder = new TextDecoder();
+        return JSON.parse(decoder.decode(content));
     }
 
     /**

--- a/src/driver/DriverUtils.ts
+++ b/src/driver/DriverUtils.ts
@@ -1,6 +1,6 @@
 import { Driver } from "./Driver.ts";
 import { hash } from "../util/StringUtils.ts";
-import type { AutoSavable, AutoSavableDriver } from "./types/AutoSavable.ts";
+import type { AutoSavableDriver } from "./types/AutoSavable.ts";
 
     /**
  * Common driver utility functions.

--- a/src/driver/mysql/MysqlDriver.ts
+++ b/src/driver/mysql/MysqlDriver.ts
@@ -19,7 +19,7 @@ import {ApplyValueTransformers} from "../../util/ApplyValueTransformers.ts";
 import {NotImplementedError} from "../../error/NotImplementedError.ts";
 import type * as DenoMysql from "../../../vendor/https/deno.land/x/mysql/mod.ts";
 import type {ReleaseConnection, RawExecuteResult} from "./typings.ts";
-import {deferred} from "../../../vendor/https/deno.land/std/util/async.ts";
+import {deferred} from "../../../vendor/https/deno.land/std/async/deferred.ts";
 
 /**
  * Organizes communication with MySQL DBMS.

--- a/src/driver/postgres/PostgresDriver.ts
+++ b/src/driver/postgres/PostgresDriver.ts
@@ -915,7 +915,7 @@ export class PostgresDriver implements Driver {
 
         // build connection options for the driver
         const connectionOptions = Object.assign({}, {
-            host: credentials.host,
+            hostname: credentials.host,
             user: credentials.username,
             password: credentials.password,
             database: credentials.database,

--- a/src/platform/PlatformTools.ts
+++ b/src/platform/PlatformTools.ts
@@ -87,6 +87,10 @@ export class PlatformTools {
         return fs.existsSync(pathStr);
     }
 
+    static readFile(filename: string): Promise<Uint8Array> {
+        return Deno.readFile(filename);
+    }
+
     static readFileSync(filename: string): Buffer {
         throw new NotImplementedError('PlatformTools.readFileSync');
     }

--- a/src/util/PromiseQueue.ts
+++ b/src/util/PromiseQueue.ts
@@ -1,4 +1,4 @@
-import {deferred, Deferred} from "../../vendor/https/deno.land/std/util/async.ts";
+import {deferred, Deferred} from "../../vendor/https/deno.land/std/async/deferred.ts";
 
 export class PromiseQueue<T> {
     private queue = [] as Array<{ fn: () => Promise<T>, promise: Deferred<T> }>;

--- a/test/deps/global.ts
+++ b/test/deps/global.ts
@@ -1,1 +1,5 @@
 (window as any)['global'] = window;
+
+// * `window.location` was removed in Deno@v1.0.0-rc1.
+// * Mocha depends on `window.location`.
+window.location = {};

--- a/test/deps/global.ts
+++ b/test/deps/global.ts
@@ -2,4 +2,6 @@
 
 // * `window.location` was removed in Deno@v1.0.0-rc1.
 // * Mocha depends on `window.location`.
-(window as any).location = {};
+if ((window as any).location == null) {
+  (window as any).location = {};
+}

--- a/test/deps/global.ts
+++ b/test/deps/global.ts
@@ -2,4 +2,4 @@
 
 // * `window.location` was removed in Deno@v1.0.0-rc1.
 // * Mocha depends on `window.location`.
-window.location = {};
+(window as any).location = {};

--- a/test/functional/relations/lazy-relations/basic-lazy-relation/basic-lazy-relations.ts
+++ b/test/functional/relations/lazy-relations/basic-lazy-relation/basic-lazy-relations.ts
@@ -9,8 +9,8 @@ import {
     Category,
 } from "./entity/Category.ts";
 import {EntitySchema} from "../../../../../src/index.ts";
-import UserSchemaJSON from "./schema/user.json";
-import ProfileSchemaJSON from "./schema/profile.json";
+import UserSchemaJSON from "./schema/user.js";
+import ProfileSchemaJSON from "./schema/profile.js";
 
 /**
  * Because lazy relations are overriding prototype is impossible to run these tests on multiple connections.

--- a/test/functional/relations/lazy-relations/basic-lazy-relation/schema/profile.js
+++ b/test/functional/relations/lazy-relations/basic-lazy-relation/schema/profile.js
@@ -1,4 +1,4 @@
-{
+export default {
   "name": "Profile",
   "table": {
     "name": "profile"

--- a/test/functional/relations/lazy-relations/basic-lazy-relation/schema/user.js
+++ b/test/functional/relations/lazy-relations/basic-lazy-relation/schema/user.js
@@ -1,4 +1,4 @@
-{
+export default {
   "name": "User",
   "table": {
     "name": "user"

--- a/test/functional/repository/basic-methods/repository-basic-methods.ts
+++ b/test/functional/repository/basic-methods/repository-basic-methods.ts
@@ -11,7 +11,7 @@ import {Blog} from "./entity/Blog.ts";
 import {Category} from "./entity/Category.ts";
 import {DeepPartial} from "../../../../src/common/DeepPartial.ts";
 import {EntitySchema} from "../../../../src/index.ts";
-import userSchema from "./schema/user.json";
+import userSchema from "./schema/user.js";
 
 describe("repository > basic methods", () => {
 

--- a/test/functional/repository/basic-methods/schema/user.js
+++ b/test/functional/repository/basic-methods/schema/user.js
@@ -1,4 +1,4 @@
-{
+export default {
   "name": "User",
   "table": {
     "name": "user"

--- a/vendor/https/deno.land/std/async/deferred.ts
+++ b/vendor/https/deno.land/std/async/deferred.ts
@@ -1,0 +1,1 @@
+export * from 'https://deno.land/std@v0.51.0/async/deferred.ts';

--- a/vendor/https/deno.land/std/fmt/colors.ts
+++ b/vendor/https/deno.land/std/fmt/colors.ts
@@ -1,1 +1,1 @@
-export * from 'https://deno.land/std@v0.42.0/fmt/colors.ts';
+export * from 'https://deno.land/std@v0.51.0/fmt/colors.ts';

--- a/vendor/https/deno.land/std/fs/mod.ts
+++ b/vendor/https/deno.land/std/fs/mod.ts
@@ -1,1 +1,1 @@
-export * from 'https://deno.land/std@v0.42.0/fs/mod.ts';
+export * from 'https://deno.land/std@v0.51.0/fs/mod.ts';

--- a/vendor/https/deno.land/std/node/process.ts
+++ b/vendor/https/deno.land/std/node/process.ts
@@ -1,1 +1,1 @@
-export * from 'https://deno.land/std@v0.42.0/node/process.ts';
+export * from 'https://deno.land/std@v0.51.0/node/process.ts';

--- a/vendor/https/deno.land/std/path/mod.ts
+++ b/vendor/https/deno.land/std/path/mod.ts
@@ -1,1 +1,1 @@
-export * from 'https://deno.land/std@v0.42.0/path/mod.ts';
+export * from 'https://deno.land/std@v0.51.0/path/mod.ts';

--- a/vendor/https/deno.land/std/util/async.ts
+++ b/vendor/https/deno.land/std/util/async.ts
@@ -1,1 +1,0 @@
-export * from 'https://deno.land/std@v0.42.0/util/async.ts';

--- a/vendor/https/deno.land/x/mysql/mod.ts
+++ b/vendor/https/deno.land/x/mysql/mod.ts
@@ -1,1 +1,1 @@
-export * from 'https://deno.land/x/mysql@1.9.1/mod.ts';
+export * from 'https://deno.land/x/mysql@2.1.0/mod.ts';

--- a/vendor/https/deno.land/x/postgres/mod.ts
+++ b/vendor/https/deno.land/x/postgres/mod.ts
@@ -1,1 +1,1 @@
-export * from 'https://deno.land/x/postgres@v0.3.11/mod.ts';
+export * from 'https://deno.land/x/postgres@v0.4.0/mod.ts';

--- a/vendor/https/deno.land/x/sqlite/mod.ts
+++ b/vendor/https/deno.land/x/sqlite/mod.ts
@@ -1,1 +1,1 @@
-export * from 'https://deno.land/x/sqlite@73935087a1ebe9108d784503bc5474662ba54b73/mod.ts';
+export * from 'https://deno.land/x/sqlite@v1.0.0/mod.ts';

--- a/vendor/https/unpkg.com/cac/mod.js
+++ b/vendor/https/unpkg.com/cac/mod.js
@@ -1,1 +1,1 @@
-export * from 'https://unpkg.com/cac@v6.5.8/mod.js';
+export * from 'https://unpkg.com/cac@v6.5.9/mod.js';


### PR DESCRIPTION
Closes #38
- Bumped Deno to v1.0.0 in CI
- Bumped std to v0.51.0
- Bumped deno_mysql to v2.1.0
- Bumped deno-postgres to v0.4.0
- Bumped deno-sqlite to v1.0.0
- Bumped cac.js to v6.5.9
- Stopped using json imports (removed in [Deno@v1.0.0-rc1](https://github.com/denoland/deno/releases/tag/v1.0.0-rc1))