### PR TITLE
release: v0.2.23-rc5

### DIFF
--- a/src/version.ts
+++ b/src/version.ts
@@ -1,3 +1,3 @@
-export const VERSION = "v0.2.23-rc4";
+export const VERSION = "v0.2.23-rc5";
 export const MOD_URL = `https://denolib.com/denolib/typeorm@${VERSION}/mod.ts`;
 export const CLI_URL = `https://denolib.com/denolib/typeorm@${VERSION}/cli.ts`;


### PR DESCRIPTION
Closes #65.

- breaking: bump deno-sqlite to v2.1.0 (#68)
- update: bump deno to v1.1.1 and std to v0.58.0 (#74)