### PR TITLE
upgrade: Bump deno to v1.6.2 and std to v0.82.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
     - uses: actions/checkout@master
     - uses: denolib/setup-deno@master
       with:
-        deno-version: 1.5.1
+        deno-version: 1.6.2
     - name: Check cli.ts
       run: |
         deno run -A ./cli.ts version

--- a/dem.json
+++ b/dem.json
@@ -3,7 +3,7 @@
     {
       "protocol": "https",
       "path": "deno.land/std",
-      "version": "0.76.0",
+      "version": "0.82.0",
       "files": [
         "/async/deferred.ts",
         "/encoding/utf8.ts",

--- a/dem.json
+++ b/dem.json
@@ -29,7 +29,7 @@
     {
       "protocol": "https",
       "path": "deno.land/x/mysql",
-      "version": "v2.6.0",
+      "version": "v2.7.0",
       "files": [
         "/mod.ts"
       ]
@@ -37,7 +37,7 @@
     {
       "protocol": "https",
       "path": "deno.land/x/postgres",
-      "version": "v0.4.5",
+      "version": "v0.4.6",
       "files": [
         "/mod.ts"
       ]

--- a/src/query-runner/BaseQueryRunner.ts
+++ b/src/query-runner/BaseQueryRunner.ts
@@ -96,9 +96,9 @@ export abstract class BaseQueryRunner {
     // Protected Abstract Methods
     // -------------------------------------------------------------------------
 
-    protected abstract async loadTables(tablePaths: string[]): Promise<Table[]>;
+    protected abstract loadTables(tablePaths: string[]): Promise<Table[]>;
 
-    protected abstract async loadViews(tablePaths: string[]): Promise<View[]>;
+    protected abstract loadViews(tablePaths: string[]): Promise<View[]>;
 
     // -------------------------------------------------------------------------
     // Public Methods

--- a/vendor/https/deno.land/std/async/deferred.ts
+++ b/vendor/https/deno.land/std/async/deferred.ts
@@ -1,1 +1,1 @@
-export * from "https://deno.land/std@0.76.0/async/deferred.ts";
+export * from "https://deno.land/std@0.82.0/async/deferred.ts";

--- a/vendor/https/deno.land/std/encoding/utf8.ts
+++ b/vendor/https/deno.land/std/encoding/utf8.ts
@@ -1,1 +1,1 @@
-export * from "https://deno.land/std@0.76.0/encoding/utf8.ts";
+export * from "https://deno.land/std@0.82.0/encoding/utf8.ts";

--- a/vendor/https/deno.land/std/encoding/yaml.ts
+++ b/vendor/https/deno.land/std/encoding/yaml.ts
@@ -1,1 +1,1 @@
-export * from "https://deno.land/std@0.76.0/encoding/yaml.ts";
+export * from "https://deno.land/std@0.82.0/encoding/yaml.ts";

--- a/vendor/https/deno.land/std/fmt/colors.ts
+++ b/vendor/https/deno.land/std/fmt/colors.ts
@@ -1,1 +1,1 @@
-export * from "https://deno.land/std@0.76.0/fmt/colors.ts";
+export * from "https://deno.land/std@0.82.0/fmt/colors.ts";

--- a/vendor/https/deno.land/std/fs/empty_dir.ts
+++ b/vendor/https/deno.land/std/fs/empty_dir.ts
@@ -1,1 +1,1 @@
-export * from "https://deno.land/std@0.76.0/fs/empty_dir.ts";
+export * from "https://deno.land/std@0.82.0/fs/empty_dir.ts";

--- a/vendor/https/deno.land/std/fs/ensure_dir.ts
+++ b/vendor/https/deno.land/std/fs/ensure_dir.ts
@@ -1,1 +1,1 @@
-export * from "https://deno.land/std@0.76.0/fs/ensure_dir.ts";
+export * from "https://deno.land/std@0.82.0/fs/ensure_dir.ts";

--- a/vendor/https/deno.land/std/fs/exists.ts
+++ b/vendor/https/deno.land/std/fs/exists.ts
@@ -1,1 +1,1 @@
-export * from "https://deno.land/std@0.76.0/fs/exists.ts";
+export * from "https://deno.land/std@0.82.0/fs/exists.ts";

--- a/vendor/https/deno.land/std/fs/expand_glob.ts
+++ b/vendor/https/deno.land/std/fs/expand_glob.ts
@@ -1,1 +1,1 @@
-export * from "https://deno.land/std@0.76.0/fs/expand_glob.ts";
+export * from "https://deno.land/std@0.82.0/fs/expand_glob.ts";

--- a/vendor/https/deno.land/std/hash/sha256.ts
+++ b/vendor/https/deno.land/std/hash/sha256.ts
@@ -1,1 +1,1 @@
-export * from "https://deno.land/std@0.76.0/hash/sha256.ts";
+export * from "https://deno.land/std@0.82.0/hash/sha256.ts";

--- a/vendor/https/deno.land/std/node/process.ts
+++ b/vendor/https/deno.land/std/node/process.ts
@@ -1,2 +1,2 @@
-export * from "https://deno.land/std@0.76.0/node/process.ts";
-export { default } from "https://deno.land/std@0.76.0/node/process.ts";
+export * from "https://deno.land/std@0.82.0/node/process.ts";
+export { default } from "https://deno.land/std@0.82.0/node/process.ts";

--- a/vendor/https/deno.land/std/path/mod.ts
+++ b/vendor/https/deno.land/std/path/mod.ts
@@ -1,1 +1,1 @@
-export * from "https://deno.land/std@0.76.0/path/mod.ts";
+export * from "https://deno.land/std@0.82.0/path/mod.ts";

--- a/vendor/https/deno.land/x/mysql/mod.ts
+++ b/vendor/https/deno.land/x/mysql/mod.ts
@@ -1,1 +1,1 @@
-export * from "https://deno.land/x/mysql@v2.6.0/mod.ts";
+export * from "https://deno.land/x/mysql@v2.7.0/mod.ts";

--- a/vendor/https/deno.land/x/postgres/mod.ts
+++ b/vendor/https/deno.land/x/postgres/mod.ts
@@ -1,1 +1,1 @@
-export * from "https://deno.land/x/postgres@v0.4.5/mod.ts";
+export * from "https://deno.land/x/postgres@v0.4.6/mod.ts";


### PR DESCRIPTION
* This PR fixes #127.
* Bump std to v0.82.0.
* Bump deno-postgres to v0.4.6.
* Bump deno_mysql to v2.7.0.