### PR TITLE
Fix: type check errors from outdated declarations

### DIFF
--- a/src/driver/mysql/MysqlQueryRunner.ts
+++ b/src/driver/mysql/MysqlQueryRunner.ts
@@ -51,7 +51,7 @@ export class MysqlQueryRunner extends BaseQueryRunner implements QueryRunner {
      */
     protected databaseConnectionPromise!: Promise<[Connection, () => Promise<void>]>;
 
-    protected databaseConnection!: [Connection, () => Promise<void>];
+    declare protected databaseConnection: [Connection, () => Promise<void>];
 
     // -------------------------------------------------------------------------
     // Constructor

--- a/src/driver/postgres/PostgresQueryRunner.ts
+++ b/src/driver/postgres/PostgresQueryRunner.ts
@@ -54,7 +54,7 @@ export class PostgresQueryRunner extends BaseQueryRunner implements QueryRunner 
      */
     protected releaseCallback!: () => Promise<void>;
 
-    protected databaseConnection!: PoolClient;
+   declare  protected databaseConnection: PoolClient;
 
     // -------------------------------------------------------------------------
     // Constructor

--- a/src/driver/sqlite/SqliteDriver.ts
+++ b/src/driver/sqlite/SqliteDriver.ts
@@ -26,9 +26,9 @@ export class SqliteDriver extends AbstractSqliteDriver {
      */
     options: SqliteConnectionOptions;
 
-    databaseConnection!: DB;
+    declare databaseConnection: DB;
 
-    sqlite!: DenoSqlite;
+    declare sqlite: DenoSqlite;
 
 
     // -------------------------------------------------------------------------

--- a/src/driver/sqljs/SqljsDriver.ts
+++ b/src/driver/sqljs/SqljsDriver.ts
@@ -20,7 +20,7 @@ declare var window: Window;
 
 export class SqljsDriver extends AbstractSqliteDriver implements AutoSavableDriver {
     // The driver specific options.
-    options!: SqljsConnectionOptions;
+    declare options: SqljsConnectionOptions;
 
     // -------------------------------------------------------------------------
     // Constructor

--- a/src/repository/MongoRepository.ts
+++ b/src/repository/MongoRepository.ts
@@ -48,7 +48,7 @@ export class MongoRepository<Entity extends ObjectLiteral> extends Repository<En
     /**
      * Entity Manager used by this repository.
      */
-    readonly manager!: MongoEntityManager;
+    declare readonly manager: MongoEntityManager;
 
     // -------------------------------------------------------------------------
     // Overridden Methods


### PR DESCRIPTION
added declare identifier on several declarations
so that typeorm can be run with latest Deno , currently version 1.14.0